### PR TITLE
fix: Admonition format

### DIFF
--- a/documentation/talismans/how-to-make-a-custom-talisman.md
+++ b/documentation/talismans/how-to-make-a-custom-talisman.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: How to make a Talisman
 sidebar_position: 1
 ---
@@ -80,7 +80,7 @@ We support shaped and shapeless recipes. Check out [Recipes](https://plugins.aux
 :::
 
 ### The Talisman Effects Section
-:::dangerEffects Section
+:::danger Effects Section
 
 The effects section is the core functionality of the talisman. You can configure effects, conditions, filters, mutators and triggers in this section to run whilst the talisman is active.
 


### PR DESCRIPTION
Fixes missing space between admonition type and title in documentation (e.g. `:::dangerEffects Section` → `:::danger Effects Section`).