### PR TITLE
feat: Talisman Limit / Bagize Config options to skip permissions

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/talismans/bag/TalismanBag.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/talismans/bag/TalismanBag.kt
@@ -37,6 +37,11 @@ object TalismanBag {
 
     private val Player.bagSize: Int
         get() {
+            val configSize = plugin.configYml.getInt("bag.size")
+            if (configSize > 0) {
+                return configSize
+            }
+
             val prefix = "talismans.bagsize."
             var highest = -1
             for (permission in this.effectivePermissions.map { it.permission }) {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/talismans/talismans/util/TalismanUtils.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/talismans/talismans/util/TalismanUtils.kt
@@ -32,6 +32,11 @@ object TalismanUtils {
     }
 
     fun getLimit(player: Player): Int {
+        val configLimit = plugin.configYml.getInt("talisman-limit")
+        if (configLimit > 0) {
+            return configLimit
+        }
+
         val prefix = "talismans.limit."
         var highest = -1
         for (permission in player.effectivePermissions.map { it.permission }) {

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -17,3 +17,4 @@ bag:
   title: "Talisman Bag"
   blocked-item: black_stained_glass_pane name:"&cYour talisman bag is not big enough!"
   blocked-item-lore: [ ]
+  size: [ ] # Uses bag-size permission if no value is set here

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -10,6 +10,7 @@ read-inventory: true # If a player's inventory should be checked for talismans
 read-enderchest: true # If a player's ender chest should be checked for talismans
 read-shulkerboxes: true # If a player's shulker boxes should be checked for talismans
 top-level-only: true # If only the top level of any given talisman should be activated
+talisman-limit: 54  # Set to 0 to use permission-based limits instead
 
 offhand-only: false # If talismans or shulkers of talismans need to be in the offhand to work
 

--- a/eco-core/core-plugin/src/main/resources/config.yml
+++ b/eco-core/core-plugin/src/main/resources/config.yml
@@ -18,4 +18,4 @@ bag:
   title: "Talisman Bag"
   blocked-item: black_stained_glass_pane name:"&cYour talisman bag is not big enough!"
   blocked-item-lore: [ ]
-  size: [ ] # Uses bag-size permission if no value is set here
+  size: 0 # Set to 0 to use permission-based bag size instead


### PR DESCRIPTION
I've seen for a while that Permission calls for Limit and Bagsize take up unnecessary amounts of resources, so I thought adding config options would help servers that do not use different sizes/limits per-player.

It should skip the calls if a config entry > 0 is found and therefore improve Performance.